### PR TITLE
Add torchaudio to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author='CNChTu',
     author_email='2921046558@qq.com',
     url='https://github.com/CNChTu/FCPE',
-    install_requires=['einops', 'local_attention', 'torch', 'numpy'],
+    install_requires=['einops', 'local_attention', 'torchaudio', 'numpy'],
     packages=['torchfcpe'],
     package_data={'torchfcpe': ['assets/*']},
     long_description=long_description,


### PR DESCRIPTION
The **torchaudio** package is imported explicitly in [mel_extractor.py#L5](https://github.com/CNChTu/FCPE/blob/ad0e3c721a75e1d769ca4a3b8f67579e2fb9b972/torchfcpe/mel_extractor.py#L5)