### PR TITLE
add test time augmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 __pycache__/
 torchfcpe.egg-info/
+
+test**

--- a/torchfcpe/models_infer.py
+++ b/torchfcpe/models_infer.py
@@ -26,9 +26,9 @@ def ensemble_f0(f0_list, key_shift_list, tta_uv_penalty):
 
     # select best note
     # 使用动态规划选择最优的音高
-    # 惩罚1：uv的惩罚固定为超参数uv_penalty
+    # 惩罚1：uv的惩罚固定为超参数uv_penalty ** 2
     # 惩罚2：相邻帧音高的L2距离（uv和v互转的过程除外）
-    uv_penalty = tta_uv_penalty
+    uv_penalty = tta_uv_penalty**2
 
     notes = torch.cat(note_list, dim=-1)  # (B, T, len(f0_list))
     dp = torch.zeros_like(notes)  # (B, T, len(f0_list))
@@ -127,7 +127,7 @@ class InferCFNaiveMelPE(torch.nn.Module):
         output_interp_target_length: int = None,
         retur_uv: bool = False,
         test_time_augmentation: bool = False,
-        tta_uv_penalty: float = 3.0,
+        tta_uv_penalty: float = 12.0,
         tta_key_shifts: list = [0, 12, -12],
     ) -> torch.Tensor or (torch.Tensor, torch.Tensor):
         """Infer
@@ -142,7 +142,7 @@ class InferCFNaiveMelPE(torch.nn.Module):
             output_interp_target_length (int): Output interpolation target length. Default: None.
             retur_uv (bool): Return unvoiced frames. Default: False.
             test_time_augmentation (bool): Test time augmentation. If enabled, the output may be better but slower. Default: False.
-            tta_uv_penalty (float): Test time augmentation unvoiced penalty. Default: 3.0.
+            tta_uv_penalty (float): Test time augmentation unvoiced penalty. Default: 12.0.
             tta_key_shifts (list): Test time augmentation key shifts. Default: [0, 12, -12].
         return: f0 (torch.Tensor): f0 Hz, shape (B, (n_sample//hop_size + 1) or output_interp_target_length, 1).
             if return_uv is True, return f0, uv. the shape of uv(torch.Tensor) is like f0.

--- a/torchfcpe/models_infer.py
+++ b/torchfcpe/models_infer.py
@@ -15,6 +15,66 @@ from .tools import (
 from .torch_interp import batch_interp_with_replacement_detach
 
 
+def ensemble_f0(f0_list, key_shift_list, tta_uv_penalty):
+    # convert f0 to note
+    note_list = []
+    for f0, key_shift in zip(f0_list, key_shift_list):
+        f0 = f0 + (f0 == 0) * 1e-6
+        note = torch.log2(f0 / 440) * 12 + 69 - key_shift
+        note[note < 0] = 0
+        note_list.append(note)
+
+    # select best note
+    # 使用动态规划选择最优的音高
+    # 惩罚1：uv的惩罚固定为超参数uv_penalty
+    # 惩罚2：相邻帧音高的L2距离（uv和v互转的过程除外）
+    uv_penalty = tta_uv_penalty
+
+    notes = torch.cat(note_list, dim=-1)  # (B, T, len(f0_list))
+    dp = torch.zeros_like(notes)  # (B, T, len(f0_list))
+    # dp[b,t,c]表示，对于样本b，0到第t帧的所有选择中，选择第c个f0作为第t帧的结尾的最小惩罚
+    backtrack = torch.zeros_like(notes, dtype=torch.int64)  # (B, T, len(f0_list))
+    # backtrack[b,t,c]表示，对于样本b，0到第t帧的所有选择中，选择第c个f0作为第t帧的结尾时，t-1帧结尾的选择，值域为0到len(f0_list)-1
+    # init
+    dp[:, 0, :] = (notes[:, 0, :] <= 0) * uv_penalty
+    # forward
+    for t in range(1, notes.size(1)):
+        # 计算第t帧选择c的最小惩罚
+        for c in range(notes.size(2)):
+            # 情况1：当前帧选择c，是uv
+            # 只需要处理uv的惩罚
+            if notes[:, t, c] <= 0:
+                min_value, min_indices = torch.min(dp[:, t - 1, :] + uv_penalty, dim=-1)
+                dp[:, t, c] = min_value
+                backtrack[:, t, c] = min_indices
+                continue
+
+            # 情况2：当前帧选择c，是v
+            # 首先判断上一个帧是不是v
+            is_voiced = notes[:, t - 1, :] > 0
+            # 是的话，计算L2距离，不是的话，距离为0
+            if torch.any(is_voiced):
+                l2_distance = (
+                    torch.pow((notes[:, t - 1, :] - notes[:, t, c]), 2) * is_voiced
+                )
+                min_value, min_indices = torch.min(
+                    dp[:, t - 1, :] + l2_distance, dim=-1
+                )
+                dp[:, t, c] = min_value
+                backtrack[:, t, c] = min_indices
+    # backtrack
+    t = notes.size(1) - 1
+    note_result = torch.zeros_like(notes[:, :, 0])
+    min_indices = torch.argmin(dp[:, t, :], dim=-1)
+    for i in range(0, t + 1):
+        note_result[:, t - i] = notes[:, t - i, min_indices]
+        min_indices = backtrack[:, t - i, min_indices]
+
+    # convert note to f0
+    f0_result = 440 * torch.pow(2, (note_result - 69) / 12)
+    return f0_result.unsqueeze(-1)
+
+
 class InferCFNaiveMelPE(torch.nn.Module):
     """Infer CFNaiveMelPE
     Args:
@@ -39,6 +99,7 @@ class InferCFNaiveMelPE(torch.nn.Module):
         sr: [int, float],
         decoder_mode: str = "local_argmax",
         threshold: float = 0.006,
+        keyshift: [int, float] = 0,
     ) -> torch.Tensor:
         """Infer
         Args:
@@ -50,7 +111,7 @@ class InferCFNaiveMelPE(torch.nn.Module):
         """
         with torch.no_grad():
             wav = wav.to(self.tensor_device_marker.device)
-            mel = self.wav2mel(wav, sr)
+            mel = self.wav2mel(wav, sr, keyshift=keyshift)
             f0 = self.model.infer(mel, decoder=decoder_mode, threshold=threshold)
         return f0  # (B, T, 1)
 
@@ -65,6 +126,9 @@ class InferCFNaiveMelPE(torch.nn.Module):
         interp_uv: bool = False,
         output_interp_target_length: int = None,
         retur_uv: bool = False,
+        test_time_augmentation: bool = False,
+        tta_uv_penalty: float = 3.0,
+        tta_key_shifts: list = [0, 12, -12],
     ) -> torch.Tensor or (torch.Tensor, torch.Tensor):
         """Infer
         Args:
@@ -77,11 +141,25 @@ class InferCFNaiveMelPE(torch.nn.Module):
             interp_uv (bool): Interpolate unvoiced frames. Default: False.
             output_interp_target_length (int): Output interpolation target length. Default: None.
             retur_uv (bool): Return unvoiced frames. Default: False.
+            test_time_augmentation (bool): Test time augmentation. If enabled, the output may be better but slower. Default: False.
+            tta_uv_penalty (float): Test time augmentation unvoiced penalty. Default: 3.0.
+            tta_key_shifts (list): Test time augmentation key shifts. Default: [0, 12, -12].
         return: f0 (torch.Tensor): f0 Hz, shape (B, (n_sample//hop_size + 1) or output_interp_target_length, 1).
             if return_uv is True, return f0, uv. the shape of uv(torch.Tensor) is like f0.
         """
         # infer
-        f0 = self.__call__(wav, sr, decoder_mode, threshold)
+        if test_time_augmentation:
+            assert len(tta_key_shifts) > 0
+            f0 = ensemble_f0(
+                [
+                    self.__call__(wav, sr, decoder_mode, threshold, key_shift)
+                    for key_shift in tta_key_shifts
+                ],
+                tta_key_shifts,
+                tta_uv_penalty,
+            )
+        else:
+            f0 = self.__call__(wav, sr, decoder_mode, threshold)
         if f0_min is None:
             f0_min = self.args_dict["model"]["f0_min"]
         uv = (f0 < f0_min).type(f0.dtype)


### PR DESCRIPTION
when enabled, it can expand the model's tonal range and reduce erroneous outputs, but the process will be slower, the final pitch curves may become overly smooth, and the uv may be shorter.

In the `InferCFNaiveMelPE.infer` method, specify the parameter `test_time_augmentation=True`. You can also specify the parameters `tta_uv_penalty`, `tta_key_shifts` and `tta_use_origin_uv`to achieve the desired effect.

---

启用后，可以扩展模型的音域，减少错误输出，但速度会更慢，并且最终得到的音高曲线可能会过于平滑，uv也会更短。

在`InferCFNaiveMelPE.infer`方法中，指定参数`test_time_augmentation=True`。也可以同时指定参数`tta_uv_penalty`、`tta_key_shifts`和`tta_use_origin_uv`来达到想要的效果。